### PR TITLE
Adaptation to Qt 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Compiled source 
+*.o
+/build/*
+
+# Executables
+*
+!*.*
+!*/
+
+/*.pro.user
+
+*.idx
+
+*.qmake.stash
+
+# C++ objects and libs
+*.o
+*.so
+*.so.*
+*.a
+
+# Qt
+*.pro.user
+*.pro.user.*
+moc_*.cpp
+moc_*.h
+qrc_*.cpp
+ui_*.h
+.qtc_clangd*

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ It also implements the denoising methods from the following papers for compariso
 
 The code has been tested on the following platforms:
 
-* Windows 10 with Qt 5.11.2, Qt Creator 4.7.1, and MSVC 2017 Community Edition (older versions of MSVC may not work);
-* Debian Buster with Qt 5.11.1, Qt Creator 4.6.2, and GCC 8.2.0.
+* Pop!_OS 22.04 LTS with Qt 6.8.1, Qt Creator 15.0.0 and GCC 11.4.0.
 
 ### Compiling the source code:
 

--- a/src/Denoising/glexaminer.cpp
+++ b/src/Denoising/glexaminer.cpp
@@ -181,7 +181,7 @@ void GLExaminer::mouseReleaseEvent(QMouseEvent* event)
 
 void GLExaminer::wheelEvent(QWheelEvent *event)
 {
-    float dx = event->delta() * 0.5;
+    float dx = event->angleDelta().y() * 0.5f;
     zoom(dx);
 }
 

--- a/src/Denoising/glviewer.cpp
+++ b/src/Denoising/glviewer.cpp
@@ -1,17 +1,18 @@
 #include "glviewer.h"
 #include <QFileDialog>
 #include <QColorDialog>
+#include <QOpenGLFunctions>
+#include <QResizeEvent>
 
-GLViewer::GLViewer(QWidget *parent)
-    :QGLWidget(parent)
+GLViewer::GLViewer(QWindow *parent)
+    : QOpenGLWindow(QOpenGLWindow::NoPartialUpdate, parent), examiner_(nullptr), backgroundColor_(Qt::black)
 {
     examiner_ = new MeshExaminer();
 }
 
 GLViewer::~GLViewer()
 {
-    if(examiner_) delete examiner_;
-    examiner_ = NULL;
+    delete examiner_;
 }
 
 void GLViewer::mousePressEvent(QMouseEvent *event)
@@ -27,33 +28,42 @@ void GLViewer::mouseReleaseEvent(QMouseEvent *event)
 void GLViewer::mouseMoveEvent(QMouseEvent *event)
 {
     examiner_->mouseMoveEvent(event);
-    this->updateGL();
+    this->update();
 }
 
 void GLViewer::wheelEvent(QWheelEvent *event)
 {
     examiner_->wheelEvent(event);
-    this->updateGL();
+    this->update();
 }
 
 void GLViewer::mouseDoubleClickEvent(QMouseEvent*)
 {
-}
-
-void GLViewer::paintGL()
-{
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    examiner_->draw();
+    // No operation
 }
 
 void GLViewer::initializeGL()
 {
+    QOpenGLFunctions *gl = context()->functions();
+    gl->glClearColor(backgroundColor_.redF(), backgroundColor_.greenF(), backgroundColor_.blueF(), 1.0f);
     examiner_->init();
 }
 
-void GLViewer::resizeGL(int _w, int _h)
+void GLViewer::resizeEvent(QResizeEvent *event)
 {
-    examiner_->reshape(_w, _h);
+    QOpenGLWindow::resizeEvent(event);
+    if (examiner_) {
+        examiner_->reshape(event->size().width(), event->size().height());
+    }
+}
+
+void GLViewer::paintEvent(QPaintEvent*)
+{
+    QOpenGLFunctions *gl = context()->functions();
+    gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    if (examiner_) {
+        examiner_->draw();
+    }
 }
 
 void GLViewer::updateMesh(const TriMesh &_mesh)
@@ -61,7 +71,7 @@ void GLViewer::updateMesh(const TriMesh &_mesh)
     examiner_->updateMesh(_mesh);
 }
 
-void GLViewer::resetMesh(const TriMesh &_mesh, bool _need_normalize)
+void GLViewer::resetMesh(const TriMesh &_mesh, bool _needNormalize)
 {
-    examiner_->resetMesh(_mesh, _need_normalize);
+    examiner_->resetMesh(_mesh, _needNormalize);
 }

--- a/src/Denoising/glviewer.h
+++ b/src/Denoising/glviewer.h
@@ -1,62 +1,62 @@
 #ifndef GLVIEWER_H
 #define GLVIEWER_H
 
-#include <QtOpenGL>
+#include <QOpenGLWindow>
+#include <QColorDialog>
 #include "meshexaminer.h"
 
-#include <QColorDialog>
-
-class GLViewer : public QGLWidget
+class GLViewer : public QOpenGLWindow
 {
     Q_OBJECT
 
 public:
-    GLViewer(QWidget *parent = 0);
+    explicit GLViewer(QWindow *parent = nullptr);
     ~GLViewer();
 
     void updateMesh(const TriMesh &_mesh);
     void resetMesh(const TriMesh &_mesh, bool _needNormalize = false);
 
-    MeshExaminer* getExaminer(){
+    MeshExaminer* getExaminer() {
         return examiner_;
     }
 
 public slots:
-    void setDrawPointsStatus(bool _val){
+    void setDrawPointsStatus(bool _val) {
         examiner_->setDrawPointsStatus(_val);
-        this->updateGL();
+        this->update();
     }
 
-    void setDrawFacesStatus(bool _val){
+    void setDrawFacesStatus(bool _val) {
         examiner_->setDrawFacesStatus(_val);
-        this->updateGL();
+        this->update();
     }
 
-    void setDrawEdgesStatus(bool _val){
+    void setDrawEdgesStatus(bool _val) {
         examiner_->setDrawEdgesStatus(_val);
-        this->updateGL();
+        this->update();
     }
 
-    void setBackgroundColor(){
-        QColor color = QColorDialog::getColor(Qt::black, this, tr("Set Background Color!"));
-        if(!color.isValid()) return;
-        this->qglClearColor(color);
-        this->updateGL();
+    void setBackgroundColor() {
+        QColor color = QColorDialog::getColor(Qt::black, nullptr, tr("Set Background Color!"));
+        if (!color.isValid()) return;
+        backgroundColor_ = color;
+        this->update();
     }
 
 protected:
-    void mousePressEvent(QMouseEvent *event);
-    void mouseReleaseEvent(QMouseEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
-    void wheelEvent(QWheelEvent *event);
-    void mouseDoubleClickEvent(QMouseEvent *event);
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
 
-    void initializeGL();
-    void resizeGL(int _w, int _h);
-    void paintGL();
+    void initializeGL() override;
+    void resizeEvent(QResizeEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
 
 private:
     MeshExaminer *examiner_;
+    QColor backgroundColor_;
 };
 
 #endif // GLVIEWER_H

--- a/src/Denoising/main.cpp
+++ b/src/Denoising/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication::setStyle(QStyleFactory::create("cleanlooks"));
+    QApplication::setStyle(QStyleFactory::create("fusion"));
     QApplication a(argc, argv);
     MainWindow w;
     w.show();

--- a/src/Denoising/mainwindow.cpp
+++ b/src/Denoising/mainwindow.cpp
@@ -29,7 +29,8 @@ MainWindow::MainWindow(QWidget *parent) :
 
     QHBoxLayout *layout_main = new QHBoxLayout;
     layout_main->addLayout(layout_left_);
-    layout_main->addWidget(opengl_viewer_);
+    viewer_container = QWidget::createWindowContainer(opengl_viewer_, this);
+    layout_main->addWidget(viewer_container);
     layout_main->setStretch(1,1);
     this->centralWidget()->setLayout(layout_main);
 }
@@ -57,7 +58,7 @@ MainWindow::~MainWindow()
 
 void MainWindow::init()
 {
-    opengl_viewer_ = new GLViewer(this);
+    opengl_viewer_ = new GLViewer();
     data_manager_ = new DataManager();
     parameter_set_ = new ParameterSet();
     parameter_set_widget_ = NULL;
@@ -274,21 +275,21 @@ void MainWindow::TransToNoisyMesh()
 {
     data_manager_->MeshToNoisyMesh();
     opengl_viewer_->resetMesh(data_manager_->getMesh());
-    opengl_viewer_->updateGL();
+    opengl_viewer_->update();
 }
 
 void MainWindow::TransToOriginalMesh()
 {
     data_manager_->MeshToOriginalMesh();
     opengl_viewer_->resetMesh(data_manager_->getMesh());
-    opengl_viewer_->updateGL();
+    opengl_viewer_->update();
 }
 
 void MainWindow::TransToDenoisedMesh()
 {
     data_manager_->MeshToDenoisedMesh();
     opengl_viewer_->resetMesh(data_manager_->getMesh());
-    opengl_viewer_->updateGL();
+    opengl_viewer_->update();
 }
 
 void MainWindow::ClearMesh()
@@ -296,7 +297,7 @@ void MainWindow::ClearMesh()
     CloseWidget();
     data_manager_->ClearMesh();
     opengl_viewer_->resetMesh(data_manager_->getMesh());
-    opengl_viewer_->updateGL();
+    opengl_viewer_->update();
     SetActionStatus(false);
     action_import_mesh_->setEnabled(true);
 }
@@ -369,7 +370,7 @@ void MainWindow::setActionAndWidget(bool value1, bool value2)
 void MainWindow::needToUpdateGL(bool value)
 {
     opengl_viewer_->resetMesh(data_manager_->getMesh(), value);
-    opengl_viewer_->updateGL();
+    opengl_viewer_->update();
 }
 
 void MainWindow::About()

--- a/src/Denoising/mainwindow.h
+++ b/src/Denoising/mainwindow.h
@@ -97,6 +97,7 @@ private:
 private:
     // glviewer
     GLViewer *opengl_viewer_;
+    QWidget *viewer_container;
     // datamanager
     DataManager *data_manager_;
     // parameter set


### PR DESCRIPTION
## Minimal adaptation to Qt 6 and gitignore update

### Description:
This PR adapts the code to Qt 6, with updates to QOpenGLWidget handling in contrast with the obsolete QGLWidget, and added `gitignore` for build artifacts, among others.

### Changes:
- Replaced `QGLWidget` with `QOpenGLWindow` for Qt 6 compatibility.
- Updated multiple classes of GLViewer and overriding virtual functions to compile in Qt 6.
- Other minimal changes like QStyleFactory.
- Added `.gitignore` entries to exclude build files, object files, and Qt user files.

### Testing:
- Verified on Pop!_OS 22.04 LTS with Qt 6.8.1 and GCC 11.4.0.

### Feedback Request:
- **Qt 6 Migration**: Are there any additional adaptations needed that might have been overlooked?
- **New Functionalities**: Are there any new features in Qt 6 that could benefit this project?
- **.gitignore**: Is it appropriate to include the `.gitignore` or should it be modified?
- **Testing Platforms**: Should the code be tested on more platforms?
- **Branch Interest**: Is the branch in focus appropriate for this work?

